### PR TITLE
fixed docker build error

### DIFF
--- a/external/db_drivers/sqlite3/CMakeLists.txt
+++ b/external/db_drivers/sqlite3/CMakeLists.txt
@@ -7,6 +7,7 @@ if(ANDROID)
 endif()
 
 add_definitions( -DSQLITE_HAS_CODEC)
+add_definitions(-DSQLITE_HAVE_ISNAN)
 set (sqlite3_sources sqlite3.c)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Getting GCC error when using SQLite and Fast Math: “SQLite will not work correctly with the -ffast-math option of GCC”

If you look at the SQLite source code, you'll see that this error comes from SQLite's fallback implementation of sqlite3IsNaN, which relies on IEEE's quirky definition of the != operator when used with NaN operands.

If you have a working isnan function in your C library, you can #define SQLITE_HAVE_ISNAN, which will make SQLite use the existing isnan instead of rolling its own.

Or, you could just compile SQLite without -ffast-math.